### PR TITLE
feature/records-page

### DIFF
--- a/src/app/admin/_components/BlockTitle.tsx
+++ b/src/app/admin/_components/BlockTitle.tsx
@@ -12,7 +12,7 @@ const BlockTitle: React.FC<Props> = ({ title, mode = "section" }) => {
     modal: "text-base text-heading-3 font-jp",
   };
 
-  return <p className={`mb-7 font-bold ${styles[mode]}`}>{title}</p>;
+  return <p className={`mb-3 font-bold ${styles[mode]}`}>{title}</p>;
 };
 
 export default BlockTitle;

--- a/src/app/admin/_hooks/useCommittimeSummaryQuery.ts
+++ b/src/app/admin/_hooks/useCommittimeSummaryQuery.ts
@@ -1,0 +1,8 @@
+import { TotalStudyTime } from "@/schemas/committime";
+import useFetch from "./useFetch";
+
+export const useCommittimeSummaryQuery = () => {
+  return useFetch<{ totalStudyTime: TotalStudyTime }>(
+    "/api/committime/summary",
+  );
+};

--- a/src/app/admin/edit/_components/TodoCardBase.tsx
+++ b/src/app/admin/edit/_components/TodoCardBase.tsx
@@ -23,14 +23,12 @@ const TodoCardBase: React.FC<Props> = ({
   const isToggleEnabled = !!onToggle;
 
   return (
-    <div
-      className={`flex items-center justify-between ${className ?? ""}`}
-    >
+    <div className={`flex items-center justify-between ${className ?? ""}`}>
       <button
         type="button"
         onClick={onClick}
         disabled={!onClick}
-        className={`flex w-full items-center justify-between rounded-lg p-3 ${onClick ? "min-w-52 cursor-pointer rounded-xl px-4 py-2 font-semibold text-secondary hover:border-[2px] border-secondary" : ""}`}
+        className={`flex w-full items-center justify-between rounded-lg p-1 ${onClick ? "min-w-52 cursor-pointer rounded-xl border-secondary px-4 py-2 font-semibold text-secondary hover:border-[2px]" : ""}`}
       >
         <label className="flex min-w-0 items-center gap-2">
           <input
@@ -44,15 +42,18 @@ const TodoCardBase: React.FC<Props> = ({
             className="sr-only"
           />
 
-          <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 
-            ${completed ? "bg-white border-secondary" : "border-secondary"} 
-            ${isToggleEnabled ? "cursor-pointer" : "cursor-default opacity-60"}`}
+          <span
+            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 ${completed ? "border-secondary bg-white" : "border-secondary"} ${isToggleEnabled ? "cursor-pointer" : "cursor-default opacity-60"}`}
             aria-hidden="true"
           >
-            {completed && <span className="text-secondary text-sm">✓</span>}
+            {completed && <span className="text-sm text-secondary">✓</span>}
           </span>
 
-          <span className={`min-w-0 truncate text-base ${completed ? "line-through text-base" : ""}`}>{todo}</span>
+          <span
+            className={`min-w-0 truncate text-base ${completed ? "text-base line-through" : ""}`}
+          >
+            {todo}
+          </span>
         </label>
         <p className="shrink-0 text-base text-sm font-semibold">[{dueDate}]</p>
       </button>

--- a/src/app/admin/edit/page.tsx
+++ b/src/app/admin/edit/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import SectionTitle from "@/app/_components/SectionTitle";
 import GoalSection from "./_components/GoalSection";
 import TodoSection from "./_components/TodoSection";

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,6 +4,7 @@ import { useRouteGuard } from "./_hooks/useRouteGuard";
 import { usePathname, useRouter } from "next/navigation";
 import Image from "next/image";
 import { supabase } from "@/utils/supabase";
+import { toYmdLocal } from "@/lib/date";
 
 export default function AdminLayout({
   children,
@@ -12,7 +13,7 @@ export default function AdminLayout({
 }) {
   useRouteGuard();
   const router = useRouter();
-
+  const today = toYmdLocal(new Date());
   const handleLogout = async () => {
     await supabase.auth.signOut();
     alert("ログアウトしました");
@@ -56,7 +57,7 @@ export default function AdminLayout({
             <span className="font-bold">ダッシュボード</span>
           </Link>
           <Link
-            href="/admin/records"
+            href={`/admin/records/${today}`}
             className={`flex items-center gap-2 px-14 py-3 text-body text-primary hover:bg-background ${isSelected("/admin/me") && "bg-background}"}`}
           >
             <Image

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -56,7 +56,7 @@ export default function AdminLayout({
             <span className="font-bold">ダッシュボード</span>
           </Link>
           <Link
-            href=""
+            href="/admin/records"
             className={`flex items-center gap-2 px-14 py-3 text-body text-primary hover:bg-background ${isSelected("/admin/me") && "bg-background}"}`}
           >
             <Image

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -20,23 +20,40 @@ import Textarea from "@/app/_components/Textarea";
 import BlockTitle from "../../_components/BlockTitle";
 import SectionTitle from "@/app/_components/SectionTitle";
 import Input from "@/app/_components/Input";
+import { useForm } from "react-hook-form";
 
-type PageState = {
-  source: "record" | "fresh";
-  todoItems: TodoSnapshot;
+// type PageState = {
+//   source: "record" | "fresh";
+//   todoItems: TodoSnapshot;
+//   memo: string;
+//   totalStudyTime: number;
+//   committime: {
+//     targetTime: number | null;
+//     startDate: string | null;
+//     endDate: string | null;
+//   };
+// };
+
+// type StudyTimeForm = {
+//   studyHours: string;
+//   studyMinutes: string;
+// };
+
+type RecordForm = {
   memo: string;
-  totalStudyTime: number;
-  committime: {
-    targetTime: number | null;
-    startDate: string | null;
-    endDate: string | null;
+  studyHours: string;
+  studyMinutes: string;
+  todoItems: {
+    date: string;
+    items: {
+      id: number;
+      title: string;
+      isCompleted: boolean;
+      dueDate: string | null;
+    }[];
   };
 };
 
-type StudyTimeForm = {
-  studyHours: string;
-  studyMinutes: string;
-};
 
 export default function RecordsPage({ params }: { params: { date: string } }) {
   const date = params.date;
@@ -49,11 +66,26 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const { callApi } = useApi();
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [page, setPage] = useState<PageState | null>(null);
-  const [studyTime, setStudyTime] = useState<StudyTimeForm>({
+  // const [page, setPage] = useState<PageState | null>(null);
+  // const [studyTime, setStudyTime] = useState<StudyTimeForm>({
+  //   studyHours: "",
+  //   studyMinutes: "",
+  // });
+
+  const {
+  register,
+  handleSubmit,
+  reset,
+  watch,
+  setValue,
+} = useForm<RecordForm>({
+  defaultValues: {
+    memo: "",
     studyHours: "",
     studyMinutes: "",
-  });
+    todoItems: { date, items: [] },
+  },
+});
 
   useEffect(() => {
     if (recordQuery.data?.dailyRecord) {
@@ -63,30 +95,15 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       const snapshot = todoSnapshotSchema.parse(dailyRecord.todoSnapshot);
 
       const total = dailyRecord.totalStudyTime ?? 0;
-      setStudyTime({
+      reset({
+        memo: dailyRecord.memo ?? "",
         studyHours: String(Math.floor(total / 60)),
         studyMinutes: String(total % 60),
-      });
-
-      setPage({
-        source: "record",
         todoItems: snapshot,
-        memo: dailyRecord.memo ?? "",
-        totalStudyTime: total,
-        committime: {
-          targetTime: dailyRecord.commitTargetTime ?? null,
-          startDate: dailyRecord.commitStartDate
-            ? String(dailyRecord.commitStartDate)
-            : null,
-          endDate: dailyRecord.commitEndDate
-            ? String(dailyRecord.commitEndDate)
-            : null,
-        },
       });
-      return;
-    }
+        return;
+      }
 
-    setStudyTime({ studyHours: "", studyMinutes: "" });
     const committime = committimeQuery.data?.committime ?? null;
     const todos = todoQuery.data?.todos ?? [];
     const snapshot: TodoSnapshot = {
@@ -99,18 +116,13 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       })),
     };
 
-    setPage({
-      source: "fresh",
-      todoItems: snapshot,
+    reset({
       memo: "",
-      totalStudyTime: 0,
-      committime: {
-        targetTime: committime?.targetTime ?? null,
-        startDate: committime?.startDate ?? null,
-        endDate: committime?.endDate ?? null,
-      },
+      studyHours: "",
+      studyMinutes: "",
+      todoItems: snapshot,
     });
-  }, [date, recordQuery.data, todoQuery.data, committimeQuery.data]);
+  }, [date, recordQuery.data, todoQuery.data, reset]);
 
   if (
     committimeSummaryQuery.isLoading ||
@@ -138,33 +150,21 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
     return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
 
   // todo checkbox state
-  const toggleTodo = (todoId: number, next: boolean) => {
-    setPage((prev) => {
-      if (!prev) return prev;
-
-      return {
-        ...prev,
-        todoItems: {
-          ...prev.todoItems,
-          items: prev.todoItems.items.map((t) =>
-            t.id === todoId ? { ...t, isCompleted: next } : t,
-          ),
-        },
-      };
-    });
+  const todoItems = watch("todoItems");
+  const toggleTodo = (index: number, next: boolean) => {
+    setValue(`todoItems.items.${index}.isCompleted`, next);
   };
 
   // submit
-  const handleSave = async () => {
-    if (!page) return;
-
+  const onSubmit = async (data: RecordForm) => {
     const total =
-      Number(studyTime.studyHours || 0) * 60 +
-      Number(studyTime.studyMinutes || 0);
+      Number(data.studyHours || 0) * 60 +
+      Number(data.studyMinutes || 0);
+
     const payload: CreateDailyRecord = {
-      memo: page.memo,
+      memo: data.memo,
       totalStudyTime: total,
-      todoSnapshot: page.todoItems,
+      todoSnapshot: data.todoItems,
       applyTodoUpdates: true,
     };
 
@@ -198,13 +198,13 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
         <BlockTitle title="Todo list" />
         <div className="space-y-2">
-          {page?.todoItems.items.map((t) => (
+          {todoItems.items.map((t, index) => (
             <TodoCardBase
               key={t.id}
               todo={t.title}
               dueDate={t.dueDate || ""}
               completed={t.isCompleted}
-              onToggle={(next) => toggleTodo(t.id, next)}
+              onToggle={(next) => toggleTodo(index, next)}
             />
           ))}
         </div>
@@ -238,17 +238,9 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
               <div className="flex items-center gap-2">
                 <Input
                   type="number"
-                  name="studyHours"
                   placeholder="0"
-                  inputMode="numeric"
-                  value={studyTime.studyHours}
                   className="w-20 rounded-md border-2 p-2 text-center"
-                  onChange={(e) =>
-                    setStudyTime((p) => ({
-                      ...p,
-                      studyHours: e.target.value,
-                    }))
-                  }
+                  {...register("studyHours")}
                 />
                 <span className="text-base text-form-text font-medium">
                   時間
@@ -258,19 +250,12 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
               <div className="flex items-center gap-2">
                 <Input
                   type="number"
-                  name="studyMinutes"
                   placeholder="0"
                   inputMode="numeric"
                   min={0}
                   max={59}
-                  value={studyTime.studyMinutes}
                   className="w-20 rounded-md border-2 p-2 text-center"
-                  onChange={(e) =>
-                    setStudyTime((p) => ({
-                      ...p,
-                      studyMinutes: e.target.value,
-                    }))
-                  }
+                  {...register("studyMinutes")}
                 />
                 <span className="text-base text-form-text font-medium">分</span>
               </div>
@@ -298,10 +283,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         <Textarea
           id="memo"
           placeholder="今日の記録を記入してください。"
-          value={page?.memo ?? ""}
-          onChange={(e) =>
-            setPage((prev) => (prev ? { ...prev, memo: e.target.value } : prev))
-          }
+          {...register("memo")}
         />
       </section>
       <div className="mt-8 flex justify-center">

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { useApi } from "@/app/_hooks/useApi";
-import { useCommittimeQuery } from "../_hooks/useCommittimeQuery";
-import { useCommittimeSummaryQuery } from "../_hooks/useCommittimeSummaryQuery";
-import { useTodoQuery } from "../_hooks/useTodoQuery";
+import { useCommittimeQuery } from "../../_hooks/useCommittimeQuery";
+import { useCommittimeSummaryQuery } from "../../_hooks/useCommittimeSummaryQuery";
+import { useTodoQuery } from "../../_hooks/useTodoQuery";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Loading from "@/app/_components/Loading";
-import BlockTitle from "../_components/BlockTitle";
-import useFetch from "../_hooks/useFetch";
+import BlockTitle from "../../_components/BlockTitle";
+import useFetch from "../../_hooks/useFetch";
 import {
   DailyRecord,
   TodoSnapshot,
@@ -15,14 +15,14 @@ import {
 } from "@/schemas/dailyRecord";
 import { FieldProps } from "@/app/_types/type";
 import SectionTitle from "@/app/_components/SectionTitle";
-import TodoCardBase from "../edit/_components/TodoCardBase";
+import TodoCardBase from "../../edit/_components/TodoCardBase";
 import Button from "@/app/_components/Button";
 import Label from "@/app/_components/Label";
 import Textarea from "@/app/_components/Textarea";
 
 type PageState = {
   source: "record" | "fresh";
-  todoItems: TodoSnapshot; // TODO: TodoSnapshot items の型に置換
+  todoItems: TodoSnapshot;
   memo: string;
   totalStudyTime: number;
   committime: {
@@ -51,6 +51,8 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [page, setPage] = useState<PageState | null>(null);
+
+  const today = new Date();
 
   useEffect(() => {
     if (recordQuery.data?.dailyRecord) {

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -54,7 +54,6 @@ type RecordForm = {
   };
 };
 
-
 export default function RecordsPage({ params }: { params: { date: string } }) {
   const date = params.date;
   const committimeSummaryQuery = useCommittimeSummaryQuery();
@@ -72,20 +71,15 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   //   studyMinutes: "",
   // });
 
-  const {
-  register,
-  handleSubmit,
-  reset,
-  watch,
-  setValue,
-} = useForm<RecordForm>({
-  defaultValues: {
-    memo: "",
-    studyHours: "",
-    studyMinutes: "",
-    todoItems: { date, items: [] },
-  },
-});
+  const { register, handleSubmit, reset, watch, setValue } =
+    useForm<RecordForm>({
+      defaultValues: {
+        memo: "",
+        studyHours: "",
+        studyMinutes: "",
+        todoItems: { date, items: [] },
+      },
+    });
 
   useEffect(() => {
     if (recordQuery.data?.dailyRecord) {
@@ -101,8 +95,8 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         studyMinutes: String(total % 60),
         todoItems: snapshot,
       });
-        return;
-      }
+      return;
+    }
 
     const committime = committimeQuery.data?.committime ?? null;
     const todos = todoQuery.data?.todos ?? [];
@@ -158,8 +152,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   // submit
   const onSubmit = async (data: RecordForm) => {
     const total =
-      Number(data.studyHours || 0) * 60 +
-      Number(data.studyMinutes || 0);
+      Number(data.studyHours || 0) * 60 + Number(data.studyMinutes || 0);
 
     const payload: CreateDailyRecord = {
       memo: data.memo,
@@ -190,7 +183,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
     committimeSummaryQuery.data?.totalStudyTime.totalStudyTimeByPeriod ?? 0;
 
   return (
-    <div>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <div className="flex items-center justify-between">
         <SectionTitle title="Today's Record" />
         <p className="text-heading-3 font-extrabold text-primary">{date}</p>
@@ -288,12 +281,12 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       </section>
       <div className="mt-8 flex justify-center">
         <Button
+          type="submit"
           children="今日の記録を保存"
           color="red"
-          onClick={handleSave}
           disabled={isSubmitting}
         />
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -52,8 +52,6 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [page, setPage] = useState<PageState | null>(null);
 
-  const today = new Date();
-
   useEffect(() => {
     if (recordQuery.data?.dailyRecord) {
       const dailyRecord = recordQuery.data.dailyRecord;
@@ -137,8 +135,10 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
 
   return (
     <div>
-      <SectionTitle title="Today's Record" />
-      <span>date</span>
+      <div className="flex items-center justify-between">
+        <SectionTitle title="Today's Record" />
+        <p className="text-heading-3 font-extrabold text-primary">{date}</p>
+      </div>
       <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
         <BlockTitle title="Todo list" />
         <div className="space-y-2">

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -19,6 +19,7 @@ import Label from "@/app/_components/Label";
 import Textarea from "@/app/_components/Textarea";
 import BlockTitle from "../../_components/BlockTitle";
 import SectionTitle from "@/app/_components/SectionTitle";
+import Input from "@/app/_components/Input";
 
 type PageState = {
   source: "record" | "fresh";
@@ -32,12 +33,17 @@ type PageState = {
   };
 };
 
-const field: FieldProps = {
-  name: "memo",
-  title: "今日の記録",
-  type: "textarea",
-  inputProps: { placeholder: "今日の記録を記入してください。" },
+type StudyTimeForm = {
+  studyHours: number;
+  studyMinutes: number;
 };
+
+// const field: FieldProps = {
+//   name: "memo",
+//   title: "今日の記録",
+//   type: "textarea",
+//   inputProps: { placeholder: "今日の記録を記入してください。" },
+// };
 
 export default function RecordsPage({ params }: { params: { date: string } }) {
   const date = params.date;
@@ -51,6 +57,10 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [page, setPage] = useState<PageState | null>(null);
+  const [studyTime, setStudyTime] = useState<StudyTimeForm>({
+    studyHours: 0,
+    studyMinutes: 0,
+  });
 
   useEffect(() => {
     if (recordQuery.data?.dailyRecord) {
@@ -59,11 +69,17 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       // unknown型をTodoSnapshotに変換
       const snapshot = todoSnapshotSchema.parse(dailyRecord.todoSnapshot);
 
+      const total = dailyRecord.totalStudyTime ?? 0;
+      setStudyTime({
+        studyHours: Math.floor(total / 60),
+        studyMinutes: total % 60,
+      });
+
       setPage({
         source: "record",
         todoItems: snapshot,
         memo: dailyRecord.memo ?? "",
-        totalStudyTime: dailyRecord.totalStudyTime ?? 0,
+        totalStudyTime: total,
         committime: {
           targetTime: dailyRecord.commitTargetTime ?? null,
           startDate: dailyRecord.commitStartDate
@@ -77,6 +93,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       return;
     }
 
+    setStudyTime({ studyHours: 0, studyMinutes: 0 });
     const committime = committimeQuery.data?.committime ?? null;
     const todos = todoQuery.data?.todos ?? [];
     const snapshot: TodoSnapshot = {
@@ -100,13 +117,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         endDate: committime?.endDate ?? null,
       },
     });
-  }, [
-    date,
-    recordQuery.data,
-    recordQuery.error,
-    todoQuery.data,
-    committimeQuery.data,
-  ]);
+  }, [date, recordQuery.data, todoQuery.data, committimeQuery.data]);
 
   if (
     committimeSummaryQuery.isLoading ||
@@ -133,6 +144,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   if (todoQuery.error)
     return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
 
+  // todo checkbox state
   const toggleTodo = (todoId: number, next: boolean) => {
     setPage((prev) => {
       if (!prev) return prev;
@@ -185,6 +197,34 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         <div>
           <div>
             <p className="text-base">今日の学習時間</p>
+            <div>
+              <Input
+                type="number"
+                name="studyHours"
+                value={studyTime.studyHours}
+                onChange={(e) =>
+                  setStudyTime((p) => ({
+                    ...p,
+                    studyHours: Number(e.target.value),
+                  }))
+                }
+              />
+              時間
+              <Input
+                type="number"
+                name="studyMinutes"
+                min={0}
+                max={59}
+                value={studyTime.studyMinutes}
+                onChange={(e) =>
+                  setStudyTime((p) => ({
+                    ...p,
+                    studyMinutes: Number(e.target.value),
+                  }))
+                }
+              />
+              分
+            </div>
           </div>
           <div>
             <p className="text-base">合計学習時間</p>

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -8,11 +8,11 @@ import { useEffect, useState } from "react";
 import Loading from "@/app/_components/Loading";
 import useFetch from "../../_hooks/useFetch";
 import {
+  CreateDailyRecord,
   DailyRecord,
   TodoSnapshot,
   todoSnapshotSchema,
 } from "@/schemas/dailyRecord";
-import { FieldProps } from "@/app/_types/type";
 import TodoCardBase from "../../edit/_components/TodoCardBase";
 import Button from "@/app/_components/Button";
 import Label from "@/app/_components/Label";
@@ -37,13 +37,6 @@ type StudyTimeForm = {
   studyHours: number;
   studyMinutes: number;
 };
-
-// const field: FieldProps = {
-//   name: "memo",
-//   title: "今日の記録",
-//   type: "textarea",
-//   inputProps: { placeholder: "今日の記録を記入してください。" },
-// };
 
 export default function RecordsPage({ params }: { params: { date: string } }) {
   const date = params.date;
@@ -161,6 +154,33 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
     });
   };
 
+  // submit
+  const handleSave = async () => {
+    if (!page) return;
+
+    const total = studyTime.studyHours * 60 + studyTime.studyMinutes;
+    const payload: CreateDailyRecord = {
+      memo: page.memo,
+      totalStudyTime: total,
+      todoSnapshot: page.todoItems,
+      applyTodoUpdates: true,
+    };
+
+    setIsSubmitting(true);
+    try {
+      await callApi<{ dailyRecord: DailyRecord }>(
+        `/api/records/${date}`,
+        "PUT",
+        payload,
+      );
+      router.refresh();
+    } catch (error) {
+      console.error("save records failed", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <div>
       <div className="flex items-center justify-between">
@@ -244,7 +264,12 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         />
       </section>
       <div className="mt-8 flex justify-center">
-        <Button children="今日の記録を保存" color="red" onClick={() => {}} />
+        <Button
+          children="今日の記録を保存"
+          color="red"
+          onClick={handleSave}
+          disabled={isSubmitting}
+        />
       </div>
     </div>
   );

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -194,7 +194,14 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
         <BlockTitle title="Note" />
         <Label name="memo" title="今日の記録" />
-        <Textarea id="memo" placeholder="今日の記録を記入してください。" />
+        <Textarea
+          id="memo"
+          placeholder="今日の記録を記入してください。"
+          value={page?.memo ?? ""}
+          onChange={(e) =>
+            setPage((prev) => (prev ? { ...prev, memo: e.target.value } : prev))
+          }
+        />
       </section>
       <div className="mt-8 flex justify-center">
         <Button children="今日の記録を保存" color="red" onClick={() => {}} />

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -174,12 +174,17 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         payload,
       );
       router.refresh();
+      committimeSummaryQuery.mutate();
     } catch (error) {
       console.error("save records failed", error);
     } finally {
       setIsSubmitting(false);
     }
   };
+
+  // totalStudyTimeByPeriod
+  const totalStudyTimeByPeriod =
+    committimeSummaryQuery.data?.totalStudyTime.totalStudyTimeByPeriod ?? 0;
 
   return (
     <div>
@@ -203,51 +208,80 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       </section>
       <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
         <BlockTitle title="Commit time" />
-        <div>
-          <p className="text-base">目標学習時間</p>
-          <p className="text-base">
-            {page?.committime.targetTime ? page.committime.targetTime / 60 : 0}
-            時間
-          </p>
-          <span className="text-base">
-            [{`${page?.committime.startDate} - ${page?.committime.endDate}`}]
-          </span>
-        </div>
-        <hr />
-        <div>
+        <div className="mt-2 flex items-end justify-between">
           <div>
-            <p className="text-base">今日の学習時間</p>
-            <div>
-              <Input
-                type="number"
-                name="studyHours"
-                value={studyTime.studyHours}
-                onChange={(e) =>
-                  setStudyTime((p) => ({
-                    ...p,
-                    studyHours: Number(e.target.value),
-                  }))
-                }
-              />
-              時間
-              <Input
-                type="number"
-                name="studyMinutes"
-                min={0}
-                max={59}
-                value={studyTime.studyMinutes}
-                onChange={(e) =>
-                  setStudyTime((p) => ({
-                    ...p,
-                    studyMinutes: Number(e.target.value),
-                  }))
-                }
-              />
-              分
+            <p className="text-base text-form-text">目標学習時間</p>
+            <p className="ml-4 mt-4 text-base font-bold">
+              {page?.committime.targetTime
+                ? Math.floor(page.committime.targetTime / 60)
+                : 0}
+              <span className="ml-8 text-base text-form-text">時間</span>
+            </p>
+          </div>
+
+          <p className="text-base text-sm font-semibold">
+            [{page?.committime.startDate ?? "----"} -{" "}
+            {page?.committime.endDate ?? "----"}]
+          </p>
+        </div>
+
+        <div className="mt-4 border-t border-gray-200" />
+
+        <div className="mt-4 grid grid-cols-2 gap-8">
+          <div>
+            <p className="text-base text-form-text">今日の学習時間</p>
+
+            <div className="mt-4 flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  name="studyHours"
+                  value={studyTime.studyHours}
+                  className="w-20 rounded-md border-2 p-2 text-center"
+                  onChange={(e) =>
+                    setStudyTime((p) => ({
+                      ...p,
+                      studyHours: Number(e.target.value),
+                    }))
+                  }
+                />
+                <span className="text-base text-form-text font-medium">
+                  時間
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  name="studyMinutes"
+                  min={0}
+                  max={59}
+                  value={studyTime.studyMinutes}
+                  className="w-20 rounded-md border-2 p-2 text-center"
+                  onChange={(e) =>
+                    setStudyTime((p) => ({
+                      ...p,
+                      studyMinutes: Number(e.target.value),
+                    }))
+                  }
+                />
+                <span className="text-base text-form-text font-medium">分</span>
+              </div>
             </div>
           </div>
+
           <div>
-            <p className="text-base">合計学習時間</p>
+            <p className="text-base text-form-text">合計学習時間</p>
+            <p className="mt-4 text-base font-semibold">
+              {Math.floor(totalStudyTimeByPeriod / 60)}
+              <span className="mx-4 text-base text-form-text font-medium">
+                時間
+              </span>
+              {totalStudyTimeByPeriod % 60}
+              <span className="mx-4 text-base text-form-text font-medium">
+                分
+              </span>
+            </p>
           </div>
         </div>
       </section>

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -34,8 +34,8 @@ type PageState = {
 };
 
 type StudyTimeForm = {
-  studyHours: number;
-  studyMinutes: number;
+  studyHours: string;
+  studyMinutes: string;
 };
 
 export default function RecordsPage({ params }: { params: { date: string } }) {
@@ -51,8 +51,8 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [page, setPage] = useState<PageState | null>(null);
   const [studyTime, setStudyTime] = useState<StudyTimeForm>({
-    studyHours: 0,
-    studyMinutes: 0,
+    studyHours: "",
+    studyMinutes: "",
   });
 
   useEffect(() => {
@@ -64,8 +64,8 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
 
       const total = dailyRecord.totalStudyTime ?? 0;
       setStudyTime({
-        studyHours: Math.floor(total / 60),
-        studyMinutes: total % 60,
+        studyHours: String(Math.floor(total / 60)),
+        studyMinutes: String(total % 60),
       });
 
       setPage({
@@ -86,7 +86,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       return;
     }
 
-    setStudyTime({ studyHours: 0, studyMinutes: 0 });
+    setStudyTime({ studyHours: "", studyMinutes: "" });
     const committime = committimeQuery.data?.committime ?? null;
     const todos = todoQuery.data?.todos ?? [];
     const snapshot: TodoSnapshot = {
@@ -158,7 +158,9 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const handleSave = async () => {
     if (!page) return;
 
-    const total = studyTime.studyHours * 60 + studyTime.studyMinutes;
+    const total =
+      Number(studyTime.studyHours || 0) * 60 +
+      Number(studyTime.studyMinutes || 0);
     const payload: CreateDailyRecord = {
       memo: page.memo,
       totalStudyTime: total,
@@ -175,6 +177,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       );
       router.refresh();
       committimeSummaryQuery.mutate();
+      recordQuery.mutate();
     } catch (error) {
       console.error("save records failed", error);
     } finally {
@@ -236,12 +239,14 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
                 <Input
                   type="number"
                   name="studyHours"
+                  placeholder="0"
+                  inputMode="numeric"
                   value={studyTime.studyHours}
                   className="w-20 rounded-md border-2 p-2 text-center"
                   onChange={(e) =>
                     setStudyTime((p) => ({
                       ...p,
-                      studyHours: Number(e.target.value),
+                      studyHours: e.target.value,
                     }))
                   }
                 />
@@ -254,6 +259,8 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
                 <Input
                   type="number"
                   name="studyMinutes"
+                  placeholder="0"
+                  inputMode="numeric"
                   min={0}
                   max={59}
                   value={studyTime.studyMinutes}
@@ -261,7 +268,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
                   onChange={(e) =>
                     setStudyTime((p) => ({
                       ...p,
-                      studyMinutes: Number(e.target.value),
+                      studyMinutes: e.target.value,
                     }))
                   }
                 />

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -6,7 +6,6 @@ import { useTodoQuery } from "../../_hooks/useTodoQuery";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Loading from "@/app/_components/Loading";
-import BlockTitle from "../../_components/BlockTitle";
 import useFetch from "../../_hooks/useFetch";
 import {
   DailyRecord,
@@ -14,11 +13,12 @@ import {
   todoSnapshotSchema,
 } from "@/schemas/dailyRecord";
 import { FieldProps } from "@/app/_types/type";
-import SectionTitle from "@/app/_components/SectionTitle";
 import TodoCardBase from "../../edit/_components/TodoCardBase";
 import Button from "@/app/_components/Button";
 import Label from "@/app/_components/Label";
 import Textarea from "@/app/_components/Textarea";
+import BlockTitle from "../../_components/BlockTitle";
+import SectionTitle from "@/app/_components/SectionTitle";
 
 type PageState = {
   source: "record" | "fresh";
@@ -133,6 +133,22 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   if (todoQuery.error)
     return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
 
+  const toggleTodo = (todoId: number, next: boolean) => {
+    setPage((prev) => {
+      if (!prev) return prev;
+
+      return {
+        ...prev,
+        todoItems: {
+          ...prev.todoItems,
+          items: prev.todoItems.items.map((t) =>
+            t.id === todoId ? { ...t, isCompleted: next } : t,
+          ),
+        },
+      };
+    });
+  };
+
   return (
     <div>
       <div className="flex items-center justify-between">
@@ -144,10 +160,11 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         <div className="space-y-2">
           {page?.todoItems.items.map((t) => (
             <TodoCardBase
+              key={t.id}
               todo={t.title}
               dueDate={t.dueDate || ""}
               completed={t.isCompleted}
-              onClick={() => {}}
+              onToggle={(next) => toggleTodo(t.id, next)}
             />
           ))}
         </div>

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -179,7 +179,9 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         <Label name="memo" title="今日の記録" />
         <Textarea id="memo" placeholder="今日の記録を記入してください。" />
       </section>
-      <Button children="今日の記録を保存" color="red" onClick={() => {}} />
+      <div className="mt-8 flex justify-center">
+        <Button children="今日の記録を保存" color="red" onClick={() => {}} />
+      </div>
     </div>
   );
 }

--- a/src/app/admin/records/[date]/page.tsx
+++ b/src/app/admin/records/[date]/page.tsx
@@ -5,6 +5,7 @@ import { useCommittimeSummaryQuery } from "../../_hooks/useCommittimeSummaryQuer
 import { useTodoQuery } from "../../_hooks/useTodoQuery";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
 import Loading from "@/app/_components/Loading";
 import useFetch from "../../_hooks/useFetch";
 import {
@@ -20,24 +21,6 @@ import Textarea from "@/app/_components/Textarea";
 import BlockTitle from "../../_components/BlockTitle";
 import SectionTitle from "@/app/_components/SectionTitle";
 import Input from "@/app/_components/Input";
-import { useForm } from "react-hook-form";
-
-// type PageState = {
-//   source: "record" | "fresh";
-//   todoItems: TodoSnapshot;
-//   memo: string;
-//   totalStudyTime: number;
-//   committime: {
-//     targetTime: number | null;
-//     startDate: string | null;
-//     endDate: string | null;
-//   };
-// };
-
-// type StudyTimeForm = {
-//   studyHours: string;
-//   studyMinutes: string;
-// };
 
 type RecordForm = {
   memo: string;
@@ -65,11 +48,6 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const { callApi } = useApi();
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  // const [page, setPage] = useState<PageState | null>(null);
-  // const [studyTime, setStudyTime] = useState<StudyTimeForm>({
-  //   studyHours: "",
-  //   studyMinutes: "",
-  // });
 
   const { register, handleSubmit, reset, watch, setValue } =
     useForm<RecordForm>({
@@ -98,7 +76,6 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
       return;
     }
 
-    const committime = committimeQuery.data?.committime ?? null;
     const todos = todoQuery.data?.todos ?? [];
     const snapshot: TodoSnapshot = {
       date,
@@ -142,6 +119,23 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
 
   if (todoQuery.error)
     return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
+
+  // committime
+  const record = recordQuery.data?.dailyRecord ?? null;
+  const displayCommittime = {
+    targetTime:
+      record?.commitTargetTime ??
+      committimeQuery.data?.committime?.targetTime ??
+      null,
+    startDate:
+      record?.commitStartDate ??
+      committimeQuery.data?.committime?.startDate ??
+      null,
+    endDate:
+      record?.commitEndDate ??
+      committimeQuery.data?.committime?.endDate ??
+      null,
+  };
 
   // todo checkbox state
   const todoItems = watch("todoItems");
@@ -208,16 +202,16 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
           <div>
             <p className="text-base text-form-text">目標学習時間</p>
             <p className="ml-4 mt-4 text-base font-bold">
-              {page?.committime.targetTime
-                ? Math.floor(page.committime.targetTime / 60)
+              {displayCommittime.targetTime
+                ? Math.floor(displayCommittime.targetTime / 60)
                 : 0}
               <span className="ml-8 text-base text-form-text">時間</span>
             </p>
           </div>
 
           <p className="text-base text-sm font-semibold">
-            [{page?.committime.startDate ?? "----"} -{" "}
-            {page?.committime.endDate ?? "----"}]
+            [{displayCommittime.startDate ?? "----"} -{" "}
+            {displayCommittime.endDate ?? "----"}]
           </p>
         </div>
 

--- a/src/app/admin/records/page.tsx
+++ b/src/app/admin/records/page.tsx
@@ -52,31 +52,6 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [page, setPage] = useState<PageState | null>(null);
 
-  if (
-    committimeSummaryQuery.isLoading ||
-    committimeQuery.isLoading ||
-    todoQuery.isLoading
-  )
-    return <Loading />;
-
-  if (committimeSummaryQuery.error)
-    return (
-      <p>
-        合計学習時間の取得でエラーが発生しました:{" "}
-        {committimeSummaryQuery.error.message}
-      </p>
-    );
-
-  if (committimeQuery.error)
-    return (
-      <p>
-        目標時間の取得でエラーが発生しました: {committimeQuery.error.message}
-      </p>
-    );
-
-  if (todoQuery.error)
-    return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
-
   useEffect(() => {
     if (recordQuery.data?.dailyRecord) {
       const dailyRecord = recordQuery.data.dailyRecord;
@@ -133,6 +108,31 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
     committimeQuery.data,
   ]);
 
+  if (
+    committimeSummaryQuery.isLoading ||
+    committimeQuery.isLoading ||
+    todoQuery.isLoading
+  )
+    return <Loading />;
+
+  if (committimeSummaryQuery.error)
+    return (
+      <p>
+        合計学習時間の取得でエラーが発生しました:{" "}
+        {committimeSummaryQuery.error.message}
+      </p>
+    );
+
+  if (committimeQuery.error)
+    return (
+      <p>
+        目標時間の取得でエラーが発生しました: {committimeQuery.error.message}
+      </p>
+    );
+
+  if (todoQuery.error)
+    return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
+
   return (
     <div>
       <SectionTitle title="Today's Record" />
@@ -145,7 +145,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
               todo={t.title}
               dueDate={t.dueDate || ""}
               completed={t.isCompleted}
-              onClick={}
+              onClick={() => {}}
             />
           ))}
         </div>
@@ -174,7 +174,7 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         <Label name="memo" title="今日の記録" />
         <Textarea id="memo" placeholder="今日の記録を記入してください。" />
       </section>
-      <Button children="今日の記録を保存" color="red" onClick={} />
+      <Button children="今日の記録を保存" color="red" onClick={() => {}} />
     </div>
   );
 }

--- a/src/app/admin/records/page.tsx
+++ b/src/app/admin/records/page.tsx
@@ -154,7 +154,10 @@ export default function RecordsPage({ params }: { params: { date: string } }) {
         <BlockTitle title="Commit time" />
         <div>
           <p className="text-base">目標学習時間</p>
-          <p className="text-base">{page?.totalStudyTime}時間</p>
+          <p className="text-base">
+            {page?.committime.targetTime ? page.committime.targetTime / 60 : 0}
+            時間
+          </p>
           <span className="text-base">
             [{`${page?.committime.startDate} - ${page?.committime.endDate}`}]
           </span>

--- a/src/app/admin/records/page.tsx
+++ b/src/app/admin/records/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+import { useApi } from "@/app/_hooks/useApi";
+import { useCommittimeQuery } from "../_hooks/useCommittimeQuery";
+import { useCommittimeSummaryQuery } from "../_hooks/useCommittimeSummaryQuery";
+import { useTodoQuery } from "../_hooks/useTodoQuery";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import Loading from "@/app/_components/Loading";
+import BlockTitle from "../_components/BlockTitle";
+import useFetch from "../_hooks/useFetch";
+import {
+  DailyRecord,
+  TodoSnapshot,
+  todoSnapshotSchema,
+} from "@/schemas/dailyRecord";
+import { FieldProps } from "@/app/_types/type";
+import SectionTitle from "@/app/_components/SectionTitle";
+import TodoCardBase from "../edit/_components/TodoCardBase";
+import Button from "@/app/_components/Button";
+import Label from "@/app/_components/Label";
+import Textarea from "@/app/_components/Textarea";
+
+type PageState = {
+  source: "record" | "fresh";
+  todoItems: TodoSnapshot; // TODO: TodoSnapshot items の型に置換
+  memo: string;
+  totalStudyTime: number;
+  committime: {
+    targetTime: number | null;
+    startDate: string | null;
+    endDate: string | null;
+  };
+};
+
+const field: FieldProps = {
+  name: "memo",
+  title: "今日の記録",
+  type: "textarea",
+  inputProps: { placeholder: "今日の記録を記入してください。" },
+};
+
+export default function RecordsPage({ params }: { params: { date: string } }) {
+  const date = params.date;
+  const committimeSummaryQuery = useCommittimeSummaryQuery();
+  const committimeQuery = useCommittimeQuery();
+  const todoQuery = useTodoQuery();
+  const recordQuery = useFetch<{ dailyRecord: DailyRecord }>(
+    `/api/records/${date}`,
+  );
+  const { callApi } = useApi();
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [page, setPage] = useState<PageState | null>(null);
+
+  if (
+    committimeSummaryQuery.isLoading ||
+    committimeQuery.isLoading ||
+    todoQuery.isLoading
+  )
+    return <Loading />;
+
+  if (committimeSummaryQuery.error)
+    return (
+      <p>
+        合計学習時間の取得でエラーが発生しました:{" "}
+        {committimeSummaryQuery.error.message}
+      </p>
+    );
+
+  if (committimeQuery.error)
+    return (
+      <p>
+        目標時間の取得でエラーが発生しました: {committimeQuery.error.message}
+      </p>
+    );
+
+  if (todoQuery.error)
+    return <p>Todoの取得でエラーが発生しました: {todoQuery.error.message}</p>;
+
+  useEffect(() => {
+    if (recordQuery.data?.dailyRecord) {
+      const dailyRecord = recordQuery.data.dailyRecord;
+
+      // unknown型をTodoSnapshotに変換
+      const snapshot = todoSnapshotSchema.parse(dailyRecord.todoSnapshot);
+
+      setPage({
+        source: "record",
+        todoItems: snapshot,
+        memo: dailyRecord.memo ?? "",
+        totalStudyTime: dailyRecord.totalStudyTime ?? 0,
+        committime: {
+          targetTime: dailyRecord.commitTargetTime ?? null,
+          startDate: dailyRecord.commitStartDate
+            ? String(dailyRecord.commitStartDate)
+            : null,
+          endDate: dailyRecord.commitEndDate
+            ? String(dailyRecord.commitEndDate)
+            : null,
+        },
+      });
+      return;
+    }
+
+    const committime = committimeQuery.data?.committime ?? null;
+    const todos = todoQuery.data?.todos ?? [];
+    const snapshot: TodoSnapshot = {
+      date,
+      items: todos.map((todo) => ({
+        id: todo.id,
+        title: todo.title,
+        isCompleted: todo.isCompleted,
+        dueDate: todo.dueDate ?? null,
+      })),
+    };
+
+    setPage({
+      source: "fresh",
+      todoItems: snapshot,
+      memo: "",
+      totalStudyTime: 0,
+      committime: {
+        targetTime: committime?.targetTime ?? null,
+        startDate: committime?.startDate ?? null,
+        endDate: committime?.endDate ?? null,
+      },
+    });
+  }, [
+    date,
+    recordQuery.data,
+    recordQuery.error,
+    todoQuery.data,
+    committimeQuery.data,
+  ]);
+
+  return (
+    <div>
+      <SectionTitle title="Today's Record" />
+      <span>date</span>
+      <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
+        <BlockTitle title="Todo list" />
+        <div className="space-y-2">
+          {page?.todoItems.items.map((t) => (
+            <TodoCardBase
+              todo={t.title}
+              dueDate={t.dueDate || ""}
+              completed={t.isCompleted}
+              onClick={}
+            />
+          ))}
+        </div>
+      </section>
+      <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
+        <BlockTitle title="Commit time" />
+        <div>
+          <p className="text-base">目標学習時間</p>
+          <p className="text-base">{page?.totalStudyTime}時間</p>
+          <span className="text-base">
+            [{`${page?.committime.startDate} - ${page?.committime.endDate}`}]
+          </span>
+        </div>
+        <hr />
+        <div>
+          <div>
+            <p className="text-base">今日の学習時間</p>
+          </div>
+          <div>
+            <p className="text-base">合計学習時間</p>
+          </div>
+        </div>
+      </section>
+      <section className="mx-auto mb-4 w-full min-w-[580px] max-w-[760px] rounded-3xl bg-white p-6 shadow-md">
+        <BlockTitle title="Note" />
+        <Label name="memo" title="今日の記録" />
+        <Textarea id="memo" placeholder="今日の記録を記入してください。" />
+      </section>
+      <Button children="今日の記録を保存" color="red" onClick={} />
+    </div>
+  );
+}

--- a/src/app/api/committime/summary/route.ts
+++ b/src/app/api/committime/summary/route.ts
@@ -38,7 +38,7 @@ export const GET = async (request: NextRequest) => {
 
     const result = {
       committimeId: committime.id,
-      totalStudyTime: totalStudyTime._sum.totalStudyTime ?? 0,
+      totalStudyTimeByPeriod: totalStudyTime._sum.totalStudyTime ?? 0,
       startDate: committime.startDate,
       endDate: committime.endDate,
     };

--- a/src/app/api/records/[date]/route.ts
+++ b/src/app/api/records/[date]/route.ts
@@ -116,7 +116,9 @@ export const PUT = async (
           id: todo.id,
           title: todo.title,
           isCompleted: todo.isCompleted,
-          dueDate: todo.dueDate ? todo.dueDate.toISOString() : null,
+          dueDate: todo.dueDate
+            ? todo.dueDate.toISOString().slice(0, 10)
+            : null,
         })),
       };
     }

--- a/src/schemas/committime.ts
+++ b/src/schemas/committime.ts
@@ -13,7 +13,7 @@ export const committimeSchema = z.object({
 
 export const totalStudyTimeSchema = z.object({
   committimeId: z.number(),
-  totalStudyTime: z.number(),
+  totalStudyTimeByPeriod: z.number(),
   startDate: z.string(),
   endDate: z.string(),
 });

--- a/src/schemas/dailyRecord.ts
+++ b/src/schemas/dailyRecord.ts
@@ -22,7 +22,7 @@ export const todoItemSchema = z.object({
   id: z.number().int(),
   title: z.string(),
   isCompleted: z.boolean(),
-  dueDate: z.iso.datetime().nullable().optional(),
+  dueDate: z.iso.date().nullable().optional(),
 });
 
 export const todoSnapshotSchema = z.object({


### PR DESCRIPTION
### 今日の記録ページ
### 概要

今日の記録（Records）ページを新規実装し、日付ごとの記録取得 / 入力 / ローカル編集 / 保存までを一通り行えるようにしました。
Todo の完了状態、メモ、学習時間入力など「毎日触る画面」なので、UI/UX を優先して入力しやすさと状態管理の見通しを意識しています。

### 実装内容
■ ページ / ルーティング
- records/[date] ルートへ変更し、URLの日付をもとに該当日の記録を表示
- 日付の取り回しを整理し、ページ遷移・リンク生成に反映

■ 入力 & 状態管理
- memo, textarea を state と接続
- totalStudyTime を入力できるようにし、数値入力UX改善のため文字列として保持（先頭0が消えない問題などを回避）
- 保存処理（handleSave）でページ全体の編集内容をまとめて送信できる構成に整理

■ Todo 表示/操作
- Todo のチェック切り替えをローカルで即時反映（toggleTodo）
- snapshot 保存前に dueDate 表示用フォーマットを整形

### 動作確認
- [x]  records/[date] で日付に応じた表示ができること
- [x]  Todo のチェックON/OFFが即時反映され、保存後も保持されること
- [x]  memo / 学習時間を入力して保存できること
- [x]  学習時間入力で「0が残る」などの入力ストレスがないこと（文字列管理で確認）